### PR TITLE
Fix null conditional example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ The preceding code is much cleaner, easier to read and understand. On top of tha
 ```
 if (something != null)
 {
-    if (other != null)
+    if (something.Other != null)
     {
-        return whatever;
+        return something.Other.Whatever;
     }
 }
 ```
@@ -58,7 +58,7 @@ if (something != null)
 👍 Do use null conditional (?.) operator instead:
 
 ```
-return something?.other?.whatever;
+return something?.Other?.Whatever;
 ```
 
 The preceding code is also much cleaner and concise.


### PR DESCRIPTION
For the null conditional example, the 'return something?.Other?.Whatever' statement suggests that Other is a property of something and Whatever is a property of Other. In that case the in the bad code block, the container object should be added with the '.' operator. Also, following official guidelines, public properties should start with a Capital letter, so that is fixed to.