### PR TITLE
Change SomePublicMethodA() from private to public

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,7 +565,7 @@ This is just a generally accepted practice that prevents the need to hunt for va
 ```
 public class SomeClass
 {
-    private void SomePublicMethodA()
+    public void SomePublicMethodA()
     {
 
     }


### PR DESCRIPTION
SomePublicMethodA() was clearly ment to be public as it demonstrates that public methods should be before the private methods.